### PR TITLE
Use the ruby2.3 package

### DIFF
--- a/providers/agent.rb
+++ b/providers/agent.rb
@@ -76,7 +76,7 @@ end
 def install_ruby
   case node['platform_family']
   when 'debian'
-    package 'ruby2.0'
+    package 'ruby2.3'
   when 'rhel'
     package 'ruby'
   end


### PR DESCRIPTION
When attempting to run on Ubuntu 14.04 in EC2 it fails stating that the package `ruby2.0` does not exist.

Also Ruby 2.0 is out of maintenance anyway.

CC @meringu 
