### PR TITLE
Support amazon linux

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -5,7 +5,7 @@ license          'Apache-2.0'
 description      'Installs Amazon CodeDeploy agent'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 chef_version     '>= 12.5'
-version          '1.0.0'
+version          '1.0.1'
 
 supports         'Amazon'
 supports         'rhel'

--- a/resources/agent_rhel.rb
+++ b/resources/agent_rhel.rb
@@ -3,7 +3,7 @@ resource_name :code_deploy_agent
 default_action %i[install enable start]
 
 provides :code_deploy_agent_linux
-provides :code_deploy_agent, platform_family: 'rhel'
+provides :code_deploy_agent, platform_family: ['rhel', 'amazon']
 
 property :auto_update, [true, false], default: false
 


### PR DESCRIPTION
With chef 13 Amazon linux is not bundled under rhel