### PR TITLE
Fix URI containing latest version

### DIFF
--- a/libraries/helper.rb
+++ b/libraries/helper.rb
@@ -55,7 +55,7 @@ module CodeDeploy
     #
     def version_hash
       @version_hash ||= begin
-        uri = URI.parse(https_code_deploy_bucket_loc('latest/VERSION'))
+        uri = URI.parse(https_code_deploy_bucket_loc('latest/LATEST_VERSION'))
         response = Net::HTTP.get_response(uri)
         JSON.parse(response.body)
       end

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,7 +5,7 @@ license          'Apache-2.0'
 description      'Installs Amazon CodeDeploy agent'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 chef_version     '>= 12.5'
-version          '1.0.2'
+version          '1.0.3'
 
 supports         'Amazon'
 supports         'rhel'


### PR DESCRIPTION
AWS has declared latest/VERSION as deprecated:

{
   "rpm":"releases/codedeploy-agent-1.0-1.1597.noarch.rpm",
   "deb":"releases/codedeploy-agent_1.0-1.1597_all.deb",
   "msi":"releases/codedeploy-agent-1.0.1.1597.msi",
   "deprecated":"Deprecated in favor of LATEST_VERSION file"
}

So use latest/LATEST_VERSION instead.